### PR TITLE
Fix TouchService for Android 14

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,7 +42,8 @@
         <!-- 좌표 수신 후 Touch 수행 서비스 -->
         <service
             android:name=".TouchService"
-            android:exported="false" />
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
 
         <activity android:name=".MainActivity"
             android:theme="@style/Theme.Transparent"

--- a/app/src/main/java/com/example/virtualtouchpad/TouchService.kt
+++ b/app/src/main/java/com/example/virtualtouchpad/TouchService.kt
@@ -2,6 +2,7 @@ package com.example.virtualtouchpad
 
 import android.app.*
 import android.content.*
+import android.content.pm.ServiceInfo
 import android.os.Build
 import android.os.IBinder
 import android.util.Log
@@ -34,7 +35,16 @@ class TouchService : Service() {
             .setSmallIcon(android.R.drawable.ic_menu_compass)
             .build()
 
-        startForeground(1, notification)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            startForeground(
+                1,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_MANIFEST
+            )
+        } else {
+            @Suppress("DEPRECATION")
+            startForeground(1, notification)
+        }
     }
 
     private val receiver = object : BroadcastReceiver() {


### PR DESCRIPTION
## Summary
- specify the foreground service type in TouchService
- declare the type in the manifest

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68405dc54d608331b35c23bbf27899f1